### PR TITLE
fix(ui): Adjusts side nav to ensure no gap left

### DIFF
--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -8,6 +8,8 @@
     --border-color: #edebe9;
     --shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
     --shadow-hover: 0 4px 16px rgba(0, 0, 0, 0.15);
+
+    --app-footer-height: 32px;
 }
 
 /* Dark theme */
@@ -60,7 +62,7 @@ body {
     flex-direction: column;
     position: relative;
     z-index: 100;
-    height: 96%;
+    height: calc(100% - var(--app-footer-height));
 }
 
 body.dark-theme .activity-bar {
@@ -708,7 +710,7 @@ body.light-theme .activity-bar {
     bottom: 0;
     left: 0;
     right: 0;
-    height: 32px;
+    height: var(--app-footer-height);
     background-color: var(--sidebar-bg);
     border-top: 1px solid var(--border-color);
     display: flex;


### PR DESCRIPTION
Before the side-nav height was set with a percentage value to try and leave room for the footer, this broke very easily at different scaling values. 

This PR fixes that by using `calc(100% - var(--footer-height))` to ensure there is no gap at any scale.


Before:
<img width="380" height="243" alt="image" src="https://github.com/user-attachments/assets/d1057452-e5da-494e-8a85-a254c9b57d1a" />
<img width="662" height="397" alt="image" src="https://github.com/user-attachments/assets/c1ab2eca-e78b-4f4b-bcc1-9febfff04205" />


After:
<img width="753" height="513" alt="image" src="https://github.com/user-attachments/assets/7431da07-d17a-4721-9caa-fceee9a5e2e6" />
