### PR TITLE
fix target issue on the delete button

### DIFF
--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -1168,7 +1168,6 @@ async function loadConnections() {
         // Add event listeners to all connection action buttons
         connectionsList.querySelectorAll(".connection-actions button").forEach((button) => {
             button.addEventListener("click", (e) => {
-                // Use currentTarget (the button) instead of target (could be child element inside button)
                 const target = e.currentTarget as HTMLButtonElement;
                 const action = target.getAttribute("data-action");
                 const connectionId = target.getAttribute("data-connection-id");
@@ -2044,7 +2043,6 @@ async function loadSidebarConnections() {
         // Add event listeners
         connectionsList.querySelectorAll("button").forEach((button) => {
             button.addEventListener("click", async (e) => {
-                // Use currentTarget (the button) instead of target (could be img inside button)
                 const target = e.currentTarget as HTMLButtonElement;
                 const action = target.getAttribute("data-action");
                 const connectionId = target.getAttribute("data-connection-id");


### PR DESCRIPTION
There was an issue with the delete functionality for the connections.
The delete button did not trigger the functionality to delete the connection as the target was wrong.
I corrected it in the renderer and now the correct code is executed, when clicking it.
