### PR TITLE
added tenant id to modals and added the variable to the auth manager

### DIFF
--- a/src/main/managers/authManager.ts
+++ b/src/main/managers/authManager.ts
@@ -361,7 +361,8 @@ export class AuthManager {
         }
 
         const clientId = connection.clientId || "51f81489-12ee-4a9e-aaae-a2591f45987d";
-        const tokenEndpoint = `https://login.microsoftonline.com/common/oauth2/v2.0/token`;
+        const tenantId = connection.tenantId || "common";
+        const tokenEndpoint = `https://login.microsoftonline.com/${tenantId}/oauth2/v2.0/token`;
         const scope = `${connection.url}/.default`;
 
         const postData = new URLSearchParams({
@@ -540,7 +541,8 @@ export class AuthManager {
      */
     async refreshAccessToken(connection: DataverseConnection, refreshToken: string): Promise<{ accessToken: string; refreshToken?: string; expiresOn: Date }> {
         const clientId = connection.clientId || "51f81489-12ee-4a9e-aaae-a2591f45987d";
-        const tokenEndpoint = `https://login.microsoftonline.com/common/oauth2/v2.0/token`;
+        const tenantId = connection.tenantId || "common";
+        const tokenEndpoint = `https://login.microsoftonline.com/${tenantId}/oauth2/v2.0/token`;
         const scope = `${connection.url}/.default`;
 
         const postData = new URLSearchParams({

--- a/src/renderer/modals/addConnection/controller.ts
+++ b/src/renderer/modals/addConnection/controller.ts
@@ -68,6 +68,7 @@ export function getAddConnectionModalControllerScript(channels: AddConnectionMod
         optionalClientId: getInputValue("connection-optional-client-id"),
         interactiveUsername: getInputValue("connection-username"),
         interactiveTenantId: getInputValue("connection-tenant-id"),
+        usernamePasswordTenantId: getInputValue("connection-tenant-id-up"),
         connectionString: getInputValue("connection-string-input"),
     });
 

--- a/src/renderer/modals/addConnection/view.ts
+++ b/src/renderer/modals/addConnection/view.ts
@@ -80,6 +80,9 @@ export function getAddConnectionModalView(isDarkTheme: boolean): ModalViewTempla
                 <input type="password" id="connection-password" class="modal-input" placeholder="password" />
                 <button type="button" id="toggle-password" class="password-toggle-btn" aria-label="Toggle visibility">👁️</button>
             </div>
+            <label for="connection-tenant-id-up">Tenant ID (Optional)</label>
+            <input type="text" id="connection-tenant-id-up" class="modal-input" placeholder="common" />
+            <p class="helper-text">Defaults to 'common' for multi-tenant authentication. Specify your tenant ID for single-tenant apps.</p>
         </div>
         <div id="connection-string-fields" class="field-group" style="display: none">
             <span class="section-label">Connection String</span>

--- a/src/renderer/modals/editConnection/controller.ts
+++ b/src/renderer/modals/editConnection/controller.ts
@@ -80,6 +80,7 @@ export function getEditConnectionModalControllerScript(channels: EditConnectionM
         optionalClientId: getInputValue("connection-optional-client-id"),
         interactiveUsername: getInputValue("connection-username"),
         interactiveTenantId: getInputValue("connection-tenant-id"),
+        usernamePasswordTenantId: getInputValue("connection-tenant-id-up"),
         connectionString: getInputValue("connection-string-input"),
     });
 
@@ -103,6 +104,7 @@ export function getEditConnectionModalControllerScript(channels: EditConnectionM
         } else if (connection.authenticationType === "usernamePassword") {
             setInputValue("connection-username-up", connection.username);
             setInputValue("connection-password", connection.password);
+            setInputValue("connection-tenant-id-up", connection.tenantId);
         } else if (connection.authenticationType === "interactive") {
             setInputValue("connection-username", connection.username);
             setInputValue("connection-optional-client-id", connection.clientId);

--- a/src/renderer/modals/editConnection/view.ts
+++ b/src/renderer/modals/editConnection/view.ts
@@ -80,6 +80,9 @@ export function getEditConnectionModalView(isDarkTheme: boolean): ModalViewTempl
                 <input type="password" id="connection-password" class="modal-input" placeholder="password" />
                 <button type="button" id="toggle-password" class="password-toggle-btn" aria-label="Toggle visibility">👁️</button>
             </div>
+            <label for="connection-tenant-id-up">Tenant ID (Optional)</label>
+            <input type="text" id="connection-tenant-id-up" class="modal-input" placeholder="common" />
+            <p class="helper-text">Defaults to 'common' for multi-tenant authentication. Specify your tenant ID for single-tenant apps.</p>
         </div>
         <div id="connection-string-fields" class="field-group" style="display: none">
             <span class="section-label">Connection String</span>

--- a/src/renderer/modules/connectionManagement.ts
+++ b/src/renderer/modules/connectionManagement.ts
@@ -41,6 +41,7 @@ interface ConnectionFormPayload {
     optionalClientId?: string;
     interactiveUsername?: string;
     interactiveTenantId?: string;
+    usernamePasswordTenantId?: string;
     connectionString?: string;
 }
 
@@ -1148,6 +1149,7 @@ function buildConnectionFromPayload(formPayload: ConnectionFormPayload, mode: "a
     } else if (authenticationType === "usernamePassword") {
         connection.username = sanitizeInput(formPayload.username);
         connection.password = sanitizeInput(formPayload.password);
+        connection.tenantId = sanitizeInput(formPayload.usernamePasswordTenantId) || undefined;
         const optionalClientId = sanitizeInput(formPayload.optionalClientId);
         if (optionalClientId) {
             connection.clientId = optionalClientId;


### PR DESCRIPTION
1. Backend Authentication (authManager.ts)
Updated [authenticateUsernamePassword()](vscode-file://vscode-app/c:/Users/craidl/AppData/Local/Programs/Microsoft%20VS%20Code%20Insiders/aca1a9779f/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to use the tenant ID from the connection, defaulting to "common" if not specified
Updated [refreshAccessToken()](vscode-file://vscode-app/c:/Users/craidl/AppData/Local/Programs/Microsoft%20VS%20Code%20Insiders/aca1a9779f/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to also use the tenant ID from the connection
2. UI Components
Add Connection Modal: Added a "Tenant ID (Optional)" field to the username/password section
Edit Connection Modal: Added the same tenant ID field for editing existing connections
3. Form Handling
Updated both add and edit controllers to collect the tenant ID value from the new input field
Modified the [ConnectionFormPayload](vscode-file://vscode-app/c:/Users/craidl/AppData/Local/Programs/Microsoft%20VS%20Code%20Insiders/aca1a9779f/resources/app/out/vs/code/electron-browser/workbench/workbench.html) interface to include [usernamePasswordTenantId](vscode-file://vscode-app/c:/Users/craidl/AppData/Local/Programs/Microsoft%20VS%20Code%20Insiders/aca1a9779f/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Updated [buildConnectionFromPayload()](vscode-file://vscode-app/c:/Users/craidl/AppData/Local/Programs/Microsoft%20VS%20Code%20Insiders/aca1a9779f/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to set the [tenantId](vscode-file://vscode-app/c:/Users/craidl/AppData/Local/Programs/Microsoft%20VS%20Code%20Insiders/aca1a9779f/resources/app/out/vs/code/electron-browser/workbench/workbench.html) property for username/password connections
4. Data Flow
When creating or editing a connection with username/password auth, users can now specify a tenant ID
The tenant ID defaults to "common" for multi-tenant authentication, but can be customized for single-tenant scenarios
Existing connections without a tenant ID will continue to work with the default "common" value

#308 