### PR TITLE
[Feature] handle entity collection bound action/function correctly

### DIFF
--- a/src/main/managers/dataverseManager.ts
+++ b/src/main/managers/dataverseManager.ts
@@ -586,11 +586,21 @@ export class DataverseManager {
         let url = this.buildApiUrl(connection, `api/data/${DATAVERSE_API_VERSION}/`);
 
         // Build URL based on operation type
-        if (request.entityName && request.entityId) {
-            // Bound operation - use entity set name
+        if (request.entityName) {
+            
             const entitySetName = this.getEntitySetName(request.entityName);
-            url += `${entitySetName}(${request.entityId})/Microsoft.Dynamics.CRM.${request.operationName}`;
-        } else {
+            if(request.entityId)
+            {
+                // Bound operation - Entity
+                url += `${entitySetName}(${request.entityId})/Microsoft.Dynamics.CRM.${request.operationName}`;
+            }else{
+
+                // Bound operation - Entity Collection
+                url += `${entitySetName}/Microsoft.Dynamics.CRM.${request.operationName}`;
+            }
+            
+        } 
+        else {
             // Unbound operation
             url += request.operationName;
         }


### PR DESCRIPTION

If a CustomApi (action/function) is bound to an **Entity Collection**, the **entityId** field is not relevant (needed).

<img width="682" height="182" alt="image" src="https://github.com/user-attachments/assets/835b2089-ee29-4ecd-8de1-dbf24fb50144" />


The URL of this type of api must include the Entyset name and 
Ex. {**entitysetname**}/Microsoft.Dynamics.CRM.{**customapi_iniquename**}

This PR forms proper URL for these type of CustomAPI when an **entityName** is provided but no **entityId** 

ref. https://learn.microsoft.com/en-us/power-apps/developer/data-platform/custom-api


<img width="784" height="88" alt="image" src="https://github.com/user-attachments/assets/bd97a665-0f2b-4114-a1a3-c2a4497323b9" />

 
