### PR TITLE
Potential fix for code scanning alert no. 13: DOM text reinterpreted as HTML

### DIFF
--- a/src/renderer/modules/toolsSidebarManagement.ts
+++ b/src/renderer/modules/toolsSidebarManagement.ts
@@ -145,11 +145,16 @@ export async function loadSidebarTools(): Promise<void> {
             toolsList.innerHTML = `
                 <div class="empty-state">
                     <p>No matching tools</p>
-                    <p class="empty-state-hint">${emptyMessage}</p>
+                    <p class="empty-state-hint" id="empty-state-hint"></p>
                     <button class="fluent-button fluent-button-primary" id="search-marketplace-btn">Search in Marketplace</button>
                     ${hasActiveFilters ? '<a href="#" class="empty-state-link" id="clear-filters-link">Clear all filters</a>' : ""}
                 </div>
             `;
+
+            const emptyStateHint = document.getElementById("empty-state-hint");
+            if (emptyStateHint) {
+                emptyStateHint.textContent = emptyMessage;
+            }
 
             // Add event listener for the marketplace search button
             attachMarketplaceNavigationButton("search-marketplace-btn", searchTerm);


### PR DESCRIPTION
Potential fix for [https://github.com/PowerPlatformToolBox/desktop-app/security/code-scanning/13](https://github.com/PowerPlatformToolBox/desktop-app/security/code-scanning/13)

In general, to fix DOM text being reinterpreted as HTML, ensure that any user‑controlled text is either (a) inserted into the DOM using text APIs (`textContent`, `innerText`, `createTextNode`) instead of `innerHTML`, or (b) passed through a robust HTML‑encoding/escaping function before being interpolated into HTML strings that are assigned to `innerHTML`.

For this specific case, the minimal change that preserves existing UI structure is to stop interpolating `emptyMessage` inside the template that’s assigned to `innerHTML`, and instead create or select the hint element and set its `textContent`. That way, the rest of the markup (including the button and optional “clear filters” link) can still be built with `innerHTML`, but the untrusted value goes into the DOM as plain text. Concretely:

- Change the template assigned to `toolsList.innerHTML` so that the `emptyMessage` placeholder is replaced by an empty `<p>` with the same class and a stable `id`, e.g. `<p class="empty-state-hint" id="empty-state-hint"></p>`.
- Immediately after setting `innerHTML`, select that `<p>` via `getElementById` and, if found, set its `textContent = emptyMessage;`.
- Leave the rest of the logic (attaching event listeners, etc.) intact.

All of this is within `src/renderer/modules/toolsSidebarManagement.ts` in the `loadSidebarTools` function around lines 141–166. No new imports or external libraries are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
